### PR TITLE
SplitModel initial work

### DIFF
--- a/ema_workbench/__init__.py
+++ b/ema_workbench/__init__.py
@@ -5,7 +5,8 @@ from .em_framework import (Model, RealParameter, CategoricalParameter,
                            ScalarOutcome, TimeSeriesOutcome, Constant,
                            Scenario, Policy, MultiprocessingEvaluator,
                            IpyparallelEvaluator, SequentialEvaluator,
-                           ReplicatorModel, Constraint, ArrayOutcome)
+                           ReplicatorModel, Constraint, ArrayOutcome,
+                           SplitModel)
 
 from . import util
 from .util import (save_results, load_results, ema_logging, EMAError,

--- a/ema_workbench/__init__.py
+++ b/ema_workbench/__init__.py
@@ -6,7 +6,7 @@ from .em_framework import (Model, RealParameter, CategoricalParameter,
                            Scenario, Policy, MultiprocessingEvaluator,
                            IpyparallelEvaluator, SequentialEvaluator,
                            ReplicatorModel, Constraint, ArrayOutcome,
-                           SplitModel)
+                           SplitModel, MultiModel)
 
 from . import util
 from .util import (save_results, load_results, ema_logging, EMAError,

--- a/ema_workbench/em_framework/__init__.py
+++ b/ema_workbench/em_framework/__init__.py
@@ -15,7 +15,7 @@ __all__ = ["ema_parallel", "parameters"
 
 from .outcomes import (ScalarOutcome, TimeSeriesOutcome, Constraint,
                        ArrayOutcome)
-from .model import Model, FileModel, ReplicatorModel, Replicator, SingleReplication, SplitModel
+from .model import Model, FileModel, ReplicatorModel, Replicator, SingleReplication, SplitModel, MultiModel
 
 from .parameters import (RealParameter, IntegerParameter, CategoricalParameter,
                          BooleanParameter, Scenario, Policy, Constant,

--- a/ema_workbench/em_framework/__init__.py
+++ b/ema_workbench/em_framework/__init__.py
@@ -11,11 +11,11 @@ __all__ = ["ema_parallel", "parameters"
            "peform_experiments", 'optimize', "IpyparallelEvaluator",
            "MultiprocessingEvaluator", "SequentialEvaluator"
            'ReplicatorModel', "EpsilonProgress", "HyperVolume",
-           "Convergence", "ArchiveLogger", "ArrayOutcome"]
+           "Convergence", "ArchiveLogger", "ArrayOutcome", "SplitModel"]
 
 from .outcomes import (ScalarOutcome, TimeSeriesOutcome, Constraint,
                        ArrayOutcome)
-from .model import Model, FileModel, ReplicatorModel, Replicator, SingleReplication
+from .model import Model, FileModel, ReplicatorModel, Replicator, SingleReplication, SplitModel
 
 from .parameters import (RealParameter, IntegerParameter, CategoricalParameter,
                          BooleanParameter, Scenario, Policy, Constant,

--- a/ema_workbench/em_framework/util.py
+++ b/ema_workbench/em_framework/util.py
@@ -246,14 +246,15 @@ def determine_objects(models, attribute, union=True):
 
 def filter_map_by_array(dictionary, array, err_on_key_error=True):
     subset_dict = {}
-    for val in array:
-        try:
-            subset_dict[val] = dictionary[val]
-        except KeyError:
-            if err_on_key_error:
-                raise KeyError
-            else:
-                pass
+    if not array is None:
+        for val in array:
+            try:
+                subset_dict[val] = dictionary[val]
+            except KeyError:
+                if err_on_key_error:
+                    raise KeyError
+                else:
+                    pass
     return subset_dict
 
 def filter_map_by_function_args(dictionary, function, err_on_key_error=True ):

--- a/ema_workbench/em_framework/util.py
+++ b/ema_workbench/em_framework/util.py
@@ -7,6 +7,7 @@ from collections.abc import MutableMapping  # @UnusedImport
 
 import itertools
 import six
+import inspect
 
 from ..util import EMAError
 
@@ -16,7 +17,7 @@ from ..util import EMAError
 #
 # .. codeauthor::jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
 
-__all__ = ['NamedObject', 'NamedDict', 'Counter', 'representation']
+__all__ = ['NamedObject', 'NamedDict', 'Counter', 'representation', 'filter_map_by_function_args', 'filter_and_call']
 
 
 class NamedObject(object):
@@ -241,3 +242,24 @@ def determine_objects(models, attribute, union=True):
         for key in params_to_remove:
             del named_objects[key]
     return named_objects
+
+
+def filter_map_by_array(dictionary, array, err_on_key_error=True):
+    subset_dict = {}
+    for val in array:
+        try:
+            subset_dict[val] = dictionary[val]
+        except KeyError:
+            if err_on_key_error:
+                raise KeyError
+            else:
+                pass
+    return subset_dict
+
+def filter_map_by_function_args(dictionary, function, err_on_key_error=True ):
+    args = inspect.getfullargspec(function).args
+    return filter_map_by_array(dictionary, args, err_on_key_error)
+
+def filter_and_call(function, dictionary, err_on_key_error=True):
+    return (function(**filter_map_by_function_args(dictionary, function, err_on_key_error)))
+

--- a/ema_workbench/examples/lake_model_multi.py
+++ b/ema_workbench/examples/lake_model_multi.py
@@ -139,6 +139,7 @@ if __name__ == '__main__':
                        variant_report = temp_report,
                        variant_setup = temp_setup)
 
+    temp_model.outcomes = [ScalarOutcome('Pcrit')]
 
     # specify uncertainties
     lake_model.uncertainties = [RealParameter('b', 0.1, 0.45),
@@ -152,7 +153,7 @@ if __name__ == '__main__':
                          range(lake_model.time_horizon)]
 
     # specify outcomes
-    lake_model.outcomes = [ScalarOutcome('max_P',),
+    lake_model.outcomes = [ScalarOutcome('max_P'),
                            ScalarOutcome('utility'),
                            ScalarOutcome('inertia'),
                            ScalarOutcome('reliability')]

--- a/ema_workbench/examples/lake_model_multi.py
+++ b/ema_workbench/examples/lake_model_multi.py
@@ -1,0 +1,150 @@
+'''
+An example of the lake problem using the ema workbench.
+
+The model itself is adapted from the Rhodium example by Dave Hadka,
+see https://gist.github.com/dhadka/a8d7095c98130d8f73bc
+
+'''
+import math
+
+import numpy as np
+from scipy.optimize import brentq
+
+from ema_workbench import (SplitModel, RealParameter, ScalarOutcome, Constant,
+                           ema_logging, MultiprocessingEvaluator)
+from ema_workbench.em_framework.evaluators import MC
+
+
+def lake_problem_setup(
+    b=0.42,          # decay rate for P in lake (0.42 = irreversible)
+    q=2.0,           # recycling exponent
+    mean=0.02,       # mean of natural inflows
+    stdev=0.001,     # future utility discount rate
+    delta=0.98,      # standard deviation of natural inflows
+    alpha=0.4,       # utility from pollution
+    num_variants=100,    # Monte Carlo sampling of natural inflows
+    iterations = 100,
+        **kwargs):
+    try:
+        decisions = [kwargs[str(i)] for i in range(100)]
+    except KeyError:
+        decisions = [0, ] * 100
+    print ("Setting Up")
+    nvars = len(decisions)
+    return {'X': np.zeros((nvars,)),
+            'average_daily_P':  np.zeros((nvars,)),
+            'reliability' : 0.0,
+            'b': b,
+            'decisions': np.array(decisions),
+            'q': q,
+            'stdev': stdev,
+            'delta': delta,
+            'alpha': alpha,
+            'num_variants': num_variants,
+            'Pcrit': brentq(lambda x: x**q / (1 + x**q) - b * x, 0.01, 1.5),
+            'nvars': len(decisions),
+            'mean': mean,
+            'iterations': iterations,
+            'num_variants': num_variants,
+            }
+
+
+def lake_problem_update(state,
+                        iteration
+                        ):
+    X= state["X"]
+    b = state["b"]
+    q = state["q"]
+    decisions = state["decisions"]
+    natural_inflows = state["natural_inflows"]
+    nsamples = state["iterations"]
+    average_daily_P = state["average_daily_P"]
+    t = iteration
+    X[t] = (1 - b) * X[t - 1] + X[t - 1]**q / (1 + X[t - 1]**q) + \
+                decisions[t - 1] + natural_inflows[t - 1]
+    average_daily_P[t] += X[t] / float(nsamples)
+
+
+def lake_problem_variant_setup(state):
+    X= state["X"]
+    stdev=state["stdev"]
+    mean=state["mean"]
+    num_variants = state["num_variants"]
+    X[0] = 0.0
+    state["natural_inflows"] = np.random.lognormal(
+            math.log(mean**2 / math.sqrt(stdev**2 + mean**2)),
+            math.sqrt(math.log(1.0 + stdev**2 / mean**2)),
+            size=num_variants)
+
+def lake_problem_variant_report(state, report):
+    X = state["X"]
+    Pcrit = state["Pcrit"]
+    num_variants = state["num_variants"]
+
+    iterations = state["iterations"]
+    state["reliability"] += np.sum(X < Pcrit) / float(iterations * num_variants)
+
+def lake_problem_report(state):
+    print(state)
+    average_daily_P=state["average_daily_P"]
+    alpha=state["alpha"]
+    delta=state["delta"]
+    num_variants=state["num_variants"]
+    decisions=state["decisions"]
+    reliability=state["reliability"]
+    max_P = np.max(average_daily_P)
+    utility = np.sum(alpha * decisions * np.power(delta, np.arange(num_variants)))
+    inertia = np.sum(np.absolute(np.diff(decisions)) < 0.02) / float(num_variants - 1)
+
+    return max_P, utility, inertia, reliability
+
+
+if __name__ == '__main__':
+    ema_logging.log_to_stderr(ema_logging.INFO)
+    print ("in main")
+
+    # instantiate the model
+    lake_model = SplitModel('lakeproblem',
+                       update=lake_problem_update,
+                       setup=lake_problem_setup,
+                       report=lake_problem_report,
+                       iterations=100,
+                       variant_report = lake_problem_variant_report,
+                       variant_setup = lake_problem_variant_setup)
+    lake_model.time_horizon = 100
+
+    # specify uncertainties
+    lake_model.uncertainties = [RealParameter('b', 0.1, 0.45),
+                                RealParameter('q', 2.0, 4.5),
+                                RealParameter('mean', 0.01, 0.05),
+                                RealParameter('stdev', 0.001, 0.005),
+                                RealParameter('delta', 0.93, 0.99)]
+
+    # set levers, one for each time step
+    lake_model.levers = [RealParameter(str(i), 0, 0.1) for i in
+                         range(lake_model.time_horizon)]
+
+    # specify outcomes
+    lake_model.outcomes = [ScalarOutcome('max_P',),
+                           ScalarOutcome('utility'),
+                           ScalarOutcome('inertia'),
+                           ScalarOutcome('reliability')]
+
+    # override some of the defaults of the model
+    lake_model.constants = [Constant('alpha', 0.41),
+                            Constant('nsamples', 150)]
+
+    # generate some random policies by sampling over levers
+    n_scenarios = 1000
+    n_policies = 4
+    results=lake_model.run_experiment({})
+    print(results)
+
+#    with MultiprocessingEvaluator(lake_model) as evaluator:
+#        res = evaluator.perform_experiments(n_scenarios, n_policies,
+ #                                           levers_sampling=MC)
+
+#        experiments, outcomes = res
+#        print(experiments.shape)
+#        print(list(outcomes.keys()))
+#        print(list(outcomes.values()))

--- a/ema_workbench/examples/lake_model_multi.py
+++ b/ema_workbench/examples/lake_model_multi.py
@@ -98,6 +98,24 @@ def lake_problem_report(average_daily_P,
     return {'max_P': max_P, 'utility': utility, 'inertia': inertia, 'reliability': reliability}
 
 
+def temp_setup(q=2.0, b=0.42):
+   return ({'Pcrit': brentq(lambda x: x**q / (1 + x**q) - b * x, 0.01, 1.5),
+})
+
+def temp_update(Pcrit):
+    print ("updating P_crit ", Pcrit)
+    return {'Pcrit': Pcrit + np.random.normal(0,0.01)}
+
+def temp_variant_setup():
+   pass
+
+def temp_variant_report():
+   pass
+
+def temp_report(Pcrit):
+   return ({"Pcrit": Pcrit})
+
+
 if __name__ == '__main__':
     ema_logging.log_to_stderr(ema_logging.INFO)
     print ("in main")
@@ -111,6 +129,16 @@ if __name__ == '__main__':
                        variant_report = lake_problem_variant_report,
                        variant_setup = lake_problem_variant_setup)
     lake_model.time_horizon = 100
+
+
+    temp_model = SplitModel('tempproblem',
+                       update=temp_update,
+                       setup=temp_setup,
+                       report=temp_report,
+                       iterations=100,
+                       variant_report = temp_report,
+                       variant_setup = temp_setup)
+
 
     # specify uncertainties
     lake_model.uncertainties = [RealParameter('b', 0.1, 0.45),
@@ -138,8 +166,9 @@ if __name__ == '__main__':
     n_policies = 4
     results=lake_model.run_experiment({})
     print(results)
-    multi_model = MultiModel("lakeSolo")
+    multi_model = MultiModel("lakeMulti")
     multi_model.add_model(lake_model)
+    multi_model.add_model(temp_model)
     results=multi_model.run_experiment({})
     print(results)
 

--- a/ema_workbench/examples/lake_model_multi.py
+++ b/ema_workbench/examples/lake_model_multi.py
@@ -100,6 +100,8 @@ def lake_problem_report(average_daily_P,
 
 def temp_setup(q=2.0, b=0.42):
    return ({'Pcrit': brentq(lambda x: x**q / (1 + x**q) - b * x, 0.01, 1.5),
+            'q': q,
+            'b': b
 })
 
 def temp_update(Pcrit):
@@ -170,6 +172,9 @@ if __name__ == '__main__':
     multi_model = MultiModel("lakeMulti")
     multi_model.add_model(lake_model)
     multi_model.add_model(temp_model)
+    def link_func (temp_model_state, lake_model_state):
+        lake_model_state['Pcrit'] = temp_model_state['Pcrit']
+    multi_model.add_link(link_func, temp_model.name, lake_model.name )
     results=multi_model.run_experiment({})
     print(results)
 

--- a/test/test_em_framework/test_multi_model.py
+++ b/test/test_em_framework/test_multi_model.py
@@ -1,0 +1,114 @@
+'''
+Created on Jul 28, 2015
+
+.. codeauthor:: jhkwakkel <j.h.kwakkel (at) tudelft (dot) nl>
+'''
+
+from __future__ import (print_function, absolute_import, unicode_literals, 
+                        division)
+
+import unittest
+
+import unittest.mock as mock
+
+
+from ema_workbench.em_framework.model import MultiModel, SplitModel
+from ema_workbench.em_framework.parameters import (RealParameter, Policy, 
+                                                   Scenario, Category,
+                                                   CategoricalParameter)
+from ema_workbench.util import EMAError
+
+class TestSplitAndMultiModel(unittest.TestCase):
+
+    def test_init(self):
+        multi_model_name = 'multimodelname'
+        
+        multi_model = MultiModel(multi_model_name)
+        
+        self.assertEqual(multi_model.name, multi_model_name)
+        self.assertRaises(EMAError, MultiModel, '', 'model name')
+        
+
+    def test_model_init(self):
+        multi_model_name = 'multimodelname'
+        split_model_name_one = 'splitmodelname1'
+        split_model_name_two = 'splitmodelname2'
+        def update_func(a=1):
+            return a
+        def setup_func(b=1):
+            return {'a': b}
+        def report_func(a=1):
+            return {'d': a}
+        def variant_setup_func(a=1):
+            return {'a': a}
+        def variant_report_func(b=1):
+            return {'e': a}
+        split_model = SplitModel(split_model_name_one,
+                           update=update_func,
+                           setup=setup_func,
+                           report=report_func,
+                           variant_setup=variant_setup_func,
+                           variant_report=variant_report_func,
+                           iterations = 1)
+
+
+        self.assertEqual(split_model.update, update_func)
+        self.assertEqual(split_model.setup, setup_func)
+        self.assertEqual(split_model.report, report_func)
+        self.assertEqual(split_model.variant_report, variant_report_func)
+        self.assertEqual(split_model.variant_setup, variant_setup_func)
+        self.assertEqual(split_model.iterations, 1)
+
+        multi_model = MultiModel(multi_model_name)
+
+        with self.assertRaises(AttributeError):
+            split_model.unknown
+
+
+    def test_run_model(self):
+
+        multi_model_name = 'multimodelname'
+        split_model_name_one = 'splitmodelname1'
+        split_model_name_two = 'splitmodelname2'
+        func = lambda a: {'a': 'a'}
+        update_func = mock.Mock(side_effect = func)
+        setup_func = mock.Mock(return_value={'a': 'a'})
+        report_func = mock.Mock(side_effect = func)
+        variant_setup_func = mock.Mock(side_effect = func)
+        variant_report_func = mock.Mock(side_effect = func)
+
+        def wrap_update_moc(a):
+           return update_func(a)
+
+        def wrap_report_moc(a):
+           return report_func(a)
+
+        def wrap_variant_setup_moc(a):
+           return variant_setup_func(a)
+
+        def wrap_variant_report_moc(a):
+           return variant_report_func(a)
+        
+        split_model = SplitModel(split_model_name_one,
+                           update=wrap_update_moc,
+                           setup=setup_func,
+                           report=wrap_report_moc,
+                           variant_setup=wrap_variant_setup_moc,
+                           variant_report=wrap_variant_report_moc,
+                           iterations = 1,
+                            num_variants=1)
+
+
+
+        split_model.run_experiment({})
+        update_func.assert_called_once_with('a')
+        variant_report_func.assert_called_once_with('a')
+        report_func.assert_called_once_with('a')
+        setup_func.assert_called_once()
+        variant_setup_func.assert_called_once_with('a')
+        # test complete translation of scenario
+
+
+if __name__ == "__main__":
+    #import sys;sys.argv = ['', 'Test.testName']
+    unittest.main()


### PR DESCRIPTION
In order to work on multi-models, you have to split up a model
into consituent parts.

This is so that the function that updates the states for a particular
time period can be seperated.

I had originally thought there needed to be 3 different sections of a
model (setup, update and report), I realised the classic model for the
lake runs a few variants of the model, and so needs something to setup a
variant (variant_setup)  and also modify the report based on the outcome of that variant (variant_report).

I've attempted to re-implement the classic lake model in the new split
variant. It is a little messier, and harder to understand.

Things that can be improved:

- Use reflection to look the variables required for a function and only
pass them in from the state. This would make them a lot cleaner. If
a plain value needs to be mutated, return a dictionary with it in and
merge it with the state?

- If there isn't variant setup/report phases don't run them.

- Tests to make sure that this new lake model says the same as the old
  ones.